### PR TITLE
Pass colors for Graphwiz schema

### DIFF
--- a/src/NiceStateMachineGenerator/GraphwizExporter.cs
+++ b/src/NiceStateMachineGenerator/GraphwizExporter.cs
@@ -80,6 +80,10 @@ namespace NiceStateMachineGenerator
                     {
                         writer.Write("; style = bold");
                     }
+                    if (state.Color != null)
+                    {
+                        writer.Write($"; color = \"{state.Color}\"");
+                    }
                     writer.WriteLine("];");
                 };
                 --writer.Indent;
@@ -215,6 +219,12 @@ namespace NiceStateMachineGenerator
             {
                 writer.Write("[style = dotted]");
             }
+
+            if (edgeDescr.Color != null)
+            {
+                writer.Write($"[color = \"{edgeDescr.Color}\"]");
+            }
+
             writer.WriteLine(";");
         }
 

--- a/src/NiceStateMachineGenerator/Parser.cs
+++ b/src/NiceStateMachineGenerator/Parser.cs
@@ -264,6 +264,7 @@ namespace NiceStateMachineGenerator
             }
 
             stateDescr!.IsFinal = ParserHelper.GetJBoolWithDefault(json, "final", false, handledTokens);
+            stateDescr.Color = ParserHelper.GetJString(json, "color", handledTokens, out JToken? _, required: false);
 
             //sanity check
             {
@@ -422,6 +423,8 @@ namespace NiceStateMachineGenerator
             {
                 throw new ParseValidationException(commentToken, "On traverse comment is specified, but no event required");
             };
+
+            edge.Color = ParserHelper.GetJString(description, "color", handledTokens, out JToken? _, required: false);
 
             ParserHelper.CheckAllTokensHandled(description, handledTokens);
         }

--- a/src/NiceStateMachineGenerator/StateMachineDescr.cs
+++ b/src/NiceStateMachineGenerator/StateMachineDescr.cs
@@ -125,6 +125,7 @@ namespace NiceStateMachineGenerator
         public string? TraverseEventComment { get; set; }
         public EdgeTarget? Target { get; set; }
         public Dictionary<string, EdgeTarget>? Targets { get; set; }
+        public string? Color { get; set; }
 
         public EdgeDescr(string invokerName, bool isTimer)
         {
@@ -147,6 +148,7 @@ namespace NiceStateMachineGenerator
         public Dictionary<string, EdgeDescr>? TimerEdges { get; set; }
         public string? NextStateName { get; set; }
         public bool IsFinal { get; set; }
+        public string? Color { get; set; }
 
         public StateDescr(string name)
         {


### PR DESCRIPTION
This PR adds "color" attribute for event description and state description. Example:

```json
"FooState": {
  "baz_event": {
    "on_traverse": "event_only",
    "state": "BarState",
    "color": "#2244ff"
  },
  "color": "/spectral11/10"
}
```

Colors can be specified as:
* `#%2x%2x%2x` (RGB in hex, e.g. `#2244ff`)
*  `#%2x%2x%2x%2x` (RGBA in hex, e.g. `#2244ff58`)
* `H[, ]+S[, ]+V` (Hue-Saturation-Value, 0.0 <= H,S,V <= 1.0, e.g. `0.55,0.9,0.7`)
* as string (e.g. red, blue, green, or using some color schema, like /spectral11/10

More about graphviz colors: [color format](https://graphviz.org/docs/attr-types/color/) and [color schemas](https://graphviz.org/doc/info/colors.html)

