### PR TITLE
Mics fix for async state machine generation

### DIFF
--- a/src/NiceStateMachineGenerator/CsharpCodeExporter.cs
+++ b/src/NiceStateMachineGenerator/CsharpCodeExporter.cs
@@ -1015,6 +1015,7 @@ namespace NiceStateMachineGenerator
         private const string HEADER_CODE =
 @"
 using System;
+using System.Threading.Tasks;
 ";
 
         private const string TIMER_CODE =

--- a/src/NiceStateMachineGenerator/CsharpCodeExporter.cs
+++ b/src/NiceStateMachineGenerator/CsharpCodeExporter.cs
@@ -1051,7 +1051,8 @@ if (invocationList != null && invocationList.Length > 0)
         }
         catch (Exception ex)
         {
-            throw new Exception($""Error processing callback handler: {ex.Message}"", ex);
+            this.OnLog?.Invoke($""Error processing callback handler: {ex.Message}"");
+            throw;
         }
     }
 }";


### PR DESCRIPTION
Add `using System.Threading.Tasks` into state machine header; throw original exception while invoking async callbacks