### PR TITLE
Fix execution of d2 and dot while using daemon mode

### DIFF
--- a/src/NiceStateMachineGenerator.App/Program.cs
+++ b/src/NiceStateMachineGenerator.App/Program.cs
@@ -81,11 +81,19 @@ namespace NiceStateMachineGenerator.App
                         bool succeed = TryGenerateStateMachine(sourceFile, config);
                         if (succeed)
                         {
-                            Console.WriteLine($"Rendering Graphviz diagram at {eventArgs.FullPath}");
                             try
                             {
-                                RunGraphwiz(eventArgs.FullPath);
-                                Console.WriteLine("Render complete");
+                                if (config.run_dot)
+                                {
+                                    RunGraphwiz($"{eventArgs.FullPath}.dot");
+                                    Console.WriteLine("Graphwiz render complete");
+                                }
+
+                                if (config.run_d2)
+                                {
+                                    RunD2($"{eventArgs.FullPath}.d2", config);
+                                    Console.WriteLine("D2 render complete");
+                                }
                             }
                             catch (Exception e)
                             {
@@ -213,7 +221,7 @@ namespace NiceStateMachineGenerator.App
         private static void RunD2(string d2FileName, Config config)
         {
             Console.WriteLine("Executing D2");
-            using (Process gw = Process.Start("d2", $"-l {config.d2_layout} -t {config.d2_theme} {d2FileName} {d2FileName}.png"))
+            using (Process gw = Process.Start("d2", $"-l {config.d2_layout} -t {config.d2_theme} {d2FileName} {d2FileName}.svg"))
             {
                 gw.WaitForExit();
             }

--- a/src/NiceStateMachineGenerator/CsharpCodeExporter.cs
+++ b/src/NiceStateMachineGenerator/CsharpCodeExporter.cs
@@ -190,10 +190,12 @@ namespace NiceStateMachineGenerator
                             {
                                 if (this.m_settings.AsyncCallbacks)
                                 {
-                                    this.m_mainCodeWriter.Write("await ");
+                                    this.m_mainCodeWriter.WriteLine($"await SetState({STATES_ENUM_NAME}.{state.NextStateName}).ConfigureAwait(false);");
                                 }
-
-                                this.m_mainCodeWriter.WriteLine($"SetState({STATES_ENUM_NAME}.{state.NextStateName}).ConfigureAwait(false);");
+                                else
+                                {
+                                    this.m_mainCodeWriter.WriteLine($"SetState({STATES_ENUM_NAME}.{state.NextStateName});");
+                                }
                             }
                             this.m_mainCodeWriter.WriteLine("break;");
                         }
@@ -431,9 +433,12 @@ namespace NiceStateMachineGenerator
                                         this.m_mainCodeWriter.WriteLine($"/*{subEdge.Key}*/");
                                         if (this.m_settings.AsyncCallbacks)
                                         {
-                                            this.m_mainCodeWriter.Write($"await ");
+                                            this.m_mainCodeWriter.WriteLine($"await SetState({STATES_ENUM_NAME}.{subEdge.Value.StateName}).ConfigureAwait(false);");
                                         }
-                                        this.m_mainCodeWriter.WriteLine($"SetState({STATES_ENUM_NAME}.{subEdge.Value.StateName}).ConfigureAwait(false);");
+                                        else
+                                        {
+                                            this.m_mainCodeWriter.WriteLine($"SetState({STATES_ENUM_NAME}.{subEdge.Value.StateName});");
+                                        }
                                         this.m_mainCodeWriter.WriteLine($"break;");
                                         --this.m_mainCodeWriter.Indent;
                                     }
@@ -467,7 +472,6 @@ namespace NiceStateMachineGenerator
                     }
                     else
                     {
-
                         this.m_mainCodeWriter.WriteLine($"SetState({STATES_ENUM_NAME}.{edge.Target.StateName});");
                     }
                     break;
@@ -836,7 +840,7 @@ namespace NiceStateMachineGenerator
                 && eventArgs != null
                 && eventArgs.Count > 0;
 
-            if (!m_settings.AsyncCallbacks)
+            if (!this.m_settings.AsyncCallbacks)
             {
                 bool isGeneric = needArgs || isFunction;
 

--- a/src/NiceStateMachineGenerator/D2Exporter.cs
+++ b/src/NiceStateMachineGenerator/D2Exporter.cs
@@ -140,7 +140,7 @@ namespace NiceStateMachineGenerator
 
                     if (state.Color != null && settings.UseColors)
                     {
-                        writer.WriteLine($"style.stroke: {state.Color}");
+                        writer.WriteLine($"style.stroke: \"{state.Color}\"");
                     }
 
                     if (settings.ShowStateTimersOnOff)
@@ -291,8 +291,10 @@ namespace NiceStateMachineGenerator
 
             if (edgeDescr.Color != null && settings.UseColors)
             {
-                writer.WriteLine($"style.stroke: {edgeDescr.Color}");
+                writer.WriteLine($"style.stroke: \"{edgeDescr.Color}\"");
             }
+            
+            writer.WriteLine($"style.animated: true");
 
             writer.WriteLine("label: |||md"); //see https://d2lang.com/tour/text#standalone-text-is-markdown
             ++writer.Indent;


### PR DESCRIPTION
Hello!

Fixed paths of graph files (`*.dot`, `*.d2`) that were passed into `RunGraphwiz` and `RunD2` while running in daemon mode.

Also, changed d2 render from `.png` (render took about 12-13 seconds) to `.svg` (now takes about 1.2 seconds)