### PR TITLE
Fix generation of d2 code

### DIFF
--- a/src/NiceStateMachineGenerator/D2Exporter.cs
+++ b/src/NiceStateMachineGenerator/D2Exporter.cs
@@ -257,7 +257,9 @@ namespace NiceStateMachineGenerator
                     label += $" -> {comment}";
                 };
             };
-            writer.WriteLine($"label: {label}");
+            writer.WriteLine($"label: |||md");
+            writer.WriteLine(label);
+            writer.WriteLine($"|||");
 
             --writer.Indent;
             writer.WriteLine("}");

--- a/src/NiceStateMachineGenerator/D2Exporter.cs
+++ b/src/NiceStateMachineGenerator/D2Exporter.cs
@@ -258,7 +258,9 @@ namespace NiceStateMachineGenerator
                 };
             };
             writer.WriteLine($"label: |||md");
+            writer.Indent++;
             writer.WriteLine(label);
+            writer.Indent--;
             writer.WriteLine($"|||");
 
             --writer.Indent;


### PR DESCRIPTION
Hello!

In some cases d2 generator creates label in plain format instead of markdown:

```
connected -> stopping {
    class: event
    label: [on_enter] -> check is_stopped -> if stopped
}
```

And this leads to

```
d2 -l elk -t 8 .\schema.json.d2 schema.json.d2.svg
err: failed to compile schema.json.d2: schema.json.d2:78:22: unexpected text after array
```

This PR changes generation to markdown like so:
```
connected -> stopping {
    class: event
    label: |||md
        [on_enter] -> check is_stopped -> if stopped
    |||
}
```
